### PR TITLE
feat(api): implement permission resolution middleware for projects

### DIFF
--- a/apps/api/internal/middleware/auth.go
+++ b/apps/api/internal/middleware/auth.go
@@ -2,15 +2,10 @@ package middleware
 
 import (
 	"net/http"
-<<<<<<< HEAD
 	"strings"
 
 	"github.com/frostyeti/hyprship/apps/api/internal/routes"
 	"github.com/frostyeti/hyprship/apps/api/internal/stores"
-=======
-
-	"github.com/frostyeti/hyprship/apps/api/internal/routes"
->>>>>>> origin/master
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 )
@@ -18,12 +13,9 @@ import (
 const (
 	UserIDKey    = "userID"
 	SessionIDKey = "sessionID"
-<<<<<<< HEAD
 	RolesKey     = "roles"
 	GroupsKey    = "groups"
 	ClaimsKey    = "claims"
-=======
->>>>>>> origin/master
 )
 
 // RequireAuth is a placeholder middleware that ensures a user is authenticated.
@@ -64,7 +56,6 @@ func RequireAuth() gin.HandlerFunc {
 	}
 }
 
-<<<<<<< HEAD
 // ClaimsMiddleware injects the authenticated user's groups, roles, and claims into the context.
 func ClaimsMiddleware(userStore stores.UserStore, groupStore stores.GroupStore, roleStore stores.RoleStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -172,12 +163,6 @@ func RequireClaim(claimType, claimValue string) gin.HandlerFunc {
 			return
 		}
 
-=======
-// RequireClaim checks if the authenticated user has a specific claim/permission.
-func RequireClaim(claimType, claimValue string) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		// TODO: Validate user claims from JWT or database
->>>>>>> origin/master
 		c.Next()
 	}
 }

--- a/apps/api/internal/middleware/project_auth.go
+++ b/apps/api/internal/middleware/project_auth.go
@@ -1,0 +1,117 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/frostyeti/hyprship/apps/api/internal/routes"
+	"github.com/frostyeti/hyprship/apps/api/internal/stores"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+const (
+	ProjectPermissionsKey = "projectPermissions"
+)
+
+// ProjectPermissionsMiddleware calculates the highest bitwise permission level
+// for the authenticated user based on their group associations to the specified project.
+// It assumes ClaimsMiddleware has already run and populated the user's group IDs.
+func ProjectPermissionsMiddleware(projectStore stores.ProjectStore, projectIdParam string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Get user's groups from context (populated by ClaimsMiddleware)
+		groupsVal, exists := c.Get(GroupsKey)
+		if !exists {
+			// Not authenticated or no groups, permissions = 0
+			c.Set(ProjectPermissionsKey, int64(0))
+			c.Next()
+			return
+		}
+
+		userGroups, ok := groupsVal.([]string)
+		if !ok || len(userGroups) == 0 {
+			c.Set(ProjectPermissionsKey, int64(0))
+			c.Next()
+			return
+		}
+
+		// Parse Project ID from path parameter
+		projectIDStr := c.Param(projectIdParam)
+		if projectIDStr == "" {
+			c.Set(ProjectPermissionsKey, int64(0))
+			c.Next()
+			return
+		}
+
+		projectID, err := uuid.Parse(projectIDStr)
+		if err != nil {
+			// Try looking up project by slug if it fails UUID parse
+			project, slugErr := projectStore.GetBySlug(c.Request.Context(), projectIDStr)
+			if slugErr != nil || project == nil {
+				c.Set(ProjectPermissionsKey, int64(0))
+				c.Next()
+				return
+			}
+			projectID = project.ID
+		}
+
+		// Fetch the groups mapped to this project
+		projectGroups, err := projectStore.ListGroups(c.Request.Context(), projectID)
+		if err != nil {
+			c.Set(ProjectPermissionsKey, int64(0))
+			c.Next()
+			return
+		}
+
+		// Calculate bitwise permissions
+		var highestPerms int64 = 0
+		userGroupMap := make(map[string]bool)
+		for _, gID := range userGroups {
+			userGroupMap[gID] = true
+		}
+
+		for _, pg := range projectGroups {
+			if userGroupMap[pg.GroupID.String()] {
+				highestPerms |= pg.Permissions
+			}
+		}
+
+		c.Set(ProjectPermissionsKey, highestPerms)
+		c.Next()
+	}
+}
+
+// RequireProjectPermission ensures the user has specific permission bits for the project.
+func RequireProjectPermission(requiredPerms int64) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		permsVal, exists := c.Get(ProjectPermissionsKey)
+		if !exists {
+			c.JSON(http.StatusForbidden, routes.ErrorResponse(&routes.ApiError{
+				Code:    "forbidden",
+				Message: "Missing project permissions",
+			}))
+			c.Abort()
+			return
+		}
+
+		perms, ok := permsVal.(int64)
+		if !ok {
+			c.JSON(http.StatusForbidden, routes.ErrorResponse(&routes.ApiError{
+				Code:    "forbidden",
+				Message: "Missing project permissions",
+			}))
+			c.Abort()
+			return
+		}
+
+		if (perms & requiredPerms) != requiredPerms {
+			c.JSON(http.StatusForbidden, routes.ErrorResponse(&routes.ApiError{
+				Code:    "forbidden",
+				Message: "Insufficient project permissions",
+			}))
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/apps/api/internal/middleware/project_auth_test.go
+++ b/apps/api/internal/middleware/project_auth_test.go
@@ -1,0 +1,132 @@
+package middleware_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/frostyeti/hyprship/apps/api/internal/core"
+	"github.com/frostyeti/hyprship/apps/api/internal/middleware"
+	"github.com/frostyeti/hyprship/apps/api/internal/models"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockProjectStore struct {
+	projectGroups []models.ProjectGroup
+}
+
+func (m *mockProjectStore) ListGroups(ctx context.Context, projectID uuid.UUID) ([]models.ProjectGroup, error) {
+	return m.projectGroups, nil
+}
+func (m *mockProjectStore) GetBySlug(ctx context.Context, slug string) (*models.Project, error) {
+	return &models.Project{ID: uuid.MustParse("00000000-0000-0000-0000-000000000001")}, nil
+}
+func (m *mockProjectStore) List(ctx context.Context, opts core.ListOptions) (core.ListResult[models.Project], error) {
+	return core.ListResult[models.Project]{}, nil
+}
+func (m *mockProjectStore) Get(ctx context.Context, id uuid.UUID) (*models.Project, error) {
+	return nil, nil
+}
+func (m *mockProjectStore) Create(ctx context.Context, project *models.Project) error { return nil }
+func (m *mockProjectStore) Update(ctx context.Context, project *models.Project) error { return nil }
+func (m *mockProjectStore) Delete(ctx context.Context, id uuid.UUID) error            { return nil }
+func (m *mockProjectStore) AddGroup(ctx context.Context, projectID, groupID uuid.UUID, permissions int64) error {
+	return nil
+}
+func (m *mockProjectStore) UpdateGroupPermissions(ctx context.Context, projectID, groupID uuid.UUID, permissions int64) error {
+	return nil
+}
+func (m *mockProjectStore) RemoveGroup(ctx context.Context, projectID, groupID uuid.UUID) error {
+	return nil
+}
+
+func TestProjectPermissionsMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	projectID := uuid.New()
+	groupID1 := uuid.New()
+	groupID2 := uuid.New()
+
+	store := &mockProjectStore{
+		projectGroups: []models.ProjectGroup{
+			{ProjectID: projectID, GroupID: groupID1, Permissions: 1}, // Bit 0
+			{ProjectID: projectID, GroupID: groupID2, Permissions: 4}, // Bit 2
+		},
+	}
+
+	tests := []struct {
+		name           string
+		userGroups     []string
+		expectedPerms  int64
+		requirePerms   int64
+		expectedStatus int
+	}{
+		{
+			name:           "No groups",
+			userGroups:     nil,
+			expectedPerms:  0,
+			requirePerms:   1,
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name:           "In Group 1 only",
+			userGroups:     []string{groupID1.String()},
+			expectedPerms:  1,
+			requirePerms:   1,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "In Group 2 only",
+			userGroups:     []string{groupID2.String()},
+			expectedPerms:  4,
+			requirePerms:   4,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "In both groups",
+			userGroups:     []string{groupID1.String(), groupID2.String()},
+			expectedPerms:  5, // 1 | 4 = 5
+			requirePerms:   5,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "Lacking required perms",
+			userGroups:     []string{groupID1.String()},
+			expectedPerms:  1,
+			requirePerms:   4,
+			expectedStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := gin.New()
+
+			// Mock ClaimsMiddleware setting GroupsKey
+			r.Use(func(c *gin.Context) {
+				if tt.userGroups != nil {
+					c.Set(middleware.GroupsKey, tt.userGroups)
+				}
+				c.Next()
+			})
+
+			r.Use(middleware.ProjectPermissionsMiddleware(store, "id"))
+			r.Use(middleware.RequireProjectPermission(tt.requirePerms))
+
+			r.GET("/projects/:id", func(c *gin.Context) {
+				perms, _ := c.Get(middleware.ProjectPermissionsKey)
+				assert.Equal(t, tt.expectedPerms, perms)
+				c.Status(http.StatusOK)
+			})
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", "/projects/"+projectID.String(), nil)
+			r.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+		})
+	}
+}

--- a/apps/api/internal/routes/v1/projects.go
+++ b/apps/api/internal/routes/v1/projects.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/frostyeti/hyprship/apps/api/internal/core"
+	"github.com/frostyeti/hyprship/apps/api/internal/middleware"
 	"github.com/frostyeti/hyprship/apps/api/internal/models"
 	"github.com/frostyeti/hyprship/apps/api/internal/routes"
 	"github.com/frostyeti/hyprship/apps/api/internal/stores"
@@ -24,10 +25,13 @@ func RegisterProjectRoutes(r *gin.RouterGroup, store stores.ProjectStore) {
 	r.PUT("/:id", h.UpdateProject)
 	r.DELETE("/:id", h.DeleteProject)
 
-	r.GET("/:id/groups", h.ListProjectGroups)
-	r.POST("/:id/groups/:groupId", h.AddProjectGroup)
-	r.PUT("/:id/groups/:groupId", h.UpdateProjectGroup)
-	r.DELETE("/:id/groups/:groupId", h.RemoveProjectGroup)
+	projectSubGroup := r.Group("/:id")
+	projectSubGroup.Use(middleware.ProjectPermissionsMiddleware(store, "id"))
+
+	projectSubGroup.GET("/groups", h.ListProjectGroups)
+	projectSubGroup.POST("/groups/:groupId", h.AddProjectGroup)
+	projectSubGroup.PUT("/groups/:groupId", h.UpdateProjectGroup)
+	projectSubGroup.DELETE("/groups/:groupId", h.RemoveProjectGroup)
 }
 
 func (h *ProjectHandler) ListProjects(c *gin.Context) {

--- a/apps/api/internal/routes/v1/routes.go
+++ b/apps/api/internal/routes/v1/routes.go
@@ -10,11 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-<<<<<<< HEAD
 func RegisterRoutes(r *gin.RouterGroup, identitySvc identity.IdentityService, userStore stores.UserStore, roleStore stores.RoleStore, groupStore stores.GroupStore, projectStore stores.ProjectStore, sessionStore stores.UserSessionStore, apiKeySvc identity.APIKeyService, passkeySvc identity.PasskeyService, mfaSvc identity.MfaService, verificationSvc identity.VerificationService, importExportSvc identity.ImportExportService) {
-=======
-func RegisterRoutes(r *gin.RouterGroup, identitySvc identity.IdentityService, userStore stores.UserStore, roleStore stores.RoleStore, sessionStore stores.UserSessionStore, apiKeySvc identity.APIKeyService, passkeySvc identity.PasskeyService, mfaSvc identity.MfaService, verificationSvc identity.VerificationService, importExportSvc identity.ImportExportService) {
->>>>>>> origin/master
 	r.GET("/ping", Ping)
 	r.GET("/healthz", Healthz)
 	r.GET("/sample", Sample)
@@ -29,15 +25,12 @@ func RegisterRoutes(r *gin.RouterGroup, identitySvc identity.IdentityService, us
 
 	rolesGroup := r.Group("/roles")
 	RegisterRoleRoutes(rolesGroup, identitySvc, roleStore, importExportSvc)
-<<<<<<< HEAD
 
 	groupsGroup := r.Group("/groups")
 	RegisterGroupRoutes(groupsGroup, groupStore)
 
 	projectsGroup := r.Group("/projects")
 	RegisterProjectRoutes(projectsGroup, projectStore)
-=======
->>>>>>> origin/master
 }
 
 func Ping(c *gin.Context) {

--- a/apps/api/internal/stores/factory.go
+++ b/apps/api/internal/stores/factory.go
@@ -13,11 +13,8 @@ import (
 type StoreFactory struct {
 	UserStore                UserStore
 	RoleStore                RoleStore
-<<<<<<< HEAD
 	GroupStore               GroupStore
 	ProjectStore             ProjectStore
-=======
->>>>>>> origin/master
 	UserPasswordAuthStore    UserPasswordAuthStore
 	UserSessionStore         UserSessionStore
 	UserPasswordHistoryStore UserPasswordHistoryStore
@@ -34,11 +31,8 @@ func NewStoreFactory(driver string, db *sql.DB) (*StoreFactory, error) {
 		return &StoreFactory{
 			UserStore:                sqlite.NewUserStore(db),
 			RoleStore:                sqlite.NewRoleStore(db),
-<<<<<<< HEAD
 			GroupStore:               sqlite.NewGroupStore(db),
 			ProjectStore:             sqlite.NewProjectStore(db),
-=======
->>>>>>> origin/master
 			UserPasswordAuthStore:    sqlite.NewUserPasswordAuthStore(db),
 			UserSessionStore:         sqlite.NewUserSessionStore(db),
 			UserPasswordHistoryStore: sqlite.NewUserPasswordHistoryStore(db),
@@ -52,11 +46,8 @@ func NewStoreFactory(driver string, db *sql.DB) (*StoreFactory, error) {
 		return &StoreFactory{
 			UserStore:                pg.NewUserStore(db),
 			RoleStore:                pg.NewRoleStore(db),
-<<<<<<< HEAD
 			GroupStore:               pg.NewGroupStore(db),
 			ProjectStore:             pg.NewProjectStore(db),
-=======
->>>>>>> origin/master
 			UserPasswordAuthStore:    pg.NewUserPasswordAuthStore(db),
 			UserSessionStore:         pg.NewUserSessionStore(db),
 			UserPasswordHistoryStore: pg.NewUserPasswordHistoryStore(db),
@@ -70,11 +61,8 @@ func NewStoreFactory(driver string, db *sql.DB) (*StoreFactory, error) {
 		return &StoreFactory{
 			UserStore:                mysql.NewUserStore(db),
 			RoleStore:                mysql.NewRoleStore(db),
-<<<<<<< HEAD
 			GroupStore:               mysql.NewGroupStore(db),
 			ProjectStore:             mysql.NewProjectStore(db),
-=======
->>>>>>> origin/master
 			UserPasswordAuthStore:    mysql.NewUserPasswordAuthStore(db),
 			UserSessionStore:         mysql.NewUserSessionStore(db),
 			UserPasswordHistoryStore: mysql.NewUserPasswordHistoryStore(db),
@@ -88,11 +76,8 @@ func NewStoreFactory(driver string, db *sql.DB) (*StoreFactory, error) {
 		return &StoreFactory{
 			UserStore:                mssql.NewUserStore(db),
 			RoleStore:                mssql.NewRoleStore(db),
-<<<<<<< HEAD
 			GroupStore:               mssql.NewGroupStore(db),
 			ProjectStore:             mssql.NewProjectStore(db),
-=======
->>>>>>> origin/master
 			UserPasswordAuthStore:    mssql.NewUserPasswordAuthStore(db),
 			UserSessionStore:         mssql.NewUserSessionStore(db),
 			UserPasswordHistoryStore: mssql.NewUserPasswordHistoryStore(db),

--- a/apps/api/internal/stores/interfaces.go
+++ b/apps/api/internal/stores/interfaces.go
@@ -59,7 +59,6 @@ type RoleStore interface {
 	AddClaim(ctx context.Context, claim *models.RoleClaim) error
 	RemoveClaim(ctx context.Context, claimID int32) error
 }
-<<<<<<< HEAD
 
 type GroupStore interface {
 	List(ctx context.Context, opts core.ListOptions) (core.ListResult[models.Group], error)
@@ -96,5 +95,3 @@ type ProjectStore interface {
 	UpdateGroupPermissions(ctx context.Context, projectID, groupID uuid.UUID, permissions int64) error
 	ListGroups(ctx context.Context, projectID uuid.UUID) ([]models.ProjectGroup, error)
 }
-=======
->>>>>>> origin/master

--- a/apps/api/internal/stores/stores_integration_test.go
+++ b/apps/api/internal/stores/stores_integration_test.go
@@ -117,11 +117,8 @@ func TestStore_SQLite(t *testing.T) {
 	require.NoError(t, err)
 
 	runStoreSuite(t, sqlite.NewUserStore(conn), sqlite.NewRoleStore(conn))
-<<<<<<< HEAD
 	runGroupStoreSuite(t, sqlite.NewGroupStore(conn), sqlite.NewUserStore(conn), sqlite.NewRoleStore(conn))
 	runProjectStoreSuite(t, sqlite.NewProjectStore(conn), sqlite.NewGroupStore(conn))
-=======
->>>>>>> origin/master
 }
 
 func TestStore_Postgres(t *testing.T) {
@@ -151,11 +148,8 @@ func TestStore_Postgres(t *testing.T) {
 	require.NoError(t, err)
 
 	runStoreSuite(t, pg.NewUserStore(conn), pg.NewRoleStore(conn))
-<<<<<<< HEAD
 	runGroupStoreSuite(t, pg.NewGroupStore(conn), pg.NewUserStore(conn), pg.NewRoleStore(conn))
 	runProjectStoreSuite(t, pg.NewProjectStore(conn), pg.NewGroupStore(conn))
-=======
->>>>>>> origin/master
 }
 
 func TestStore_MySQL(t *testing.T) {
@@ -182,11 +176,8 @@ func TestStore_MySQL(t *testing.T) {
 	require.NoError(t, err)
 
 	runStoreSuite(t, mysql.NewUserStore(conn), mysql.NewRoleStore(conn))
-<<<<<<< HEAD
 	runGroupStoreSuite(t, mysql.NewGroupStore(conn), mysql.NewUserStore(conn), mysql.NewRoleStore(conn))
 	runProjectStoreSuite(t, mysql.NewProjectStore(conn), mysql.NewGroupStore(conn))
-=======
->>>>>>> origin/master
 }
 
 func TestStore_MSSQL(t *testing.T) {
@@ -211,7 +202,6 @@ func TestStore_MSSQL(t *testing.T) {
 	require.NoError(t, err)
 
 	runStoreSuite(t, mssql.NewUserStore(conn), mssql.NewRoleStore(conn))
-<<<<<<< HEAD
 	runGroupStoreSuite(t, mssql.NewGroupStore(conn), mssql.NewUserStore(conn), mssql.NewRoleStore(conn))
 	runProjectStoreSuite(t, mssql.NewProjectStore(conn), mssql.NewGroupStore(conn))
 }
@@ -430,6 +420,4 @@ func runProjectStoreSuite(t *testing.T, projectStore stores.ProjectStore, groupS
 	p4, err := projectStore.Get(ctx, project.ID)
 	require.NoError(t, err)
 	require.Nil(t, p4)
-=======
->>>>>>> origin/master
 }


### PR DESCRIPTION
## Summary
- Implements `ProjectPermissionsMiddleware` and `RequireProjectPermission`
- Calculates the highest bitwise permissions for a user from their group associations to the specified project.
- Attaches the resolved permissions to the Gin context, allowing subsequent middlewares and handlers to verify access levels.

Resolves #20 
Closes Epic #21